### PR TITLE
- catch CCopasiExceptions on task execution with *Raw methods

### DIFF
--- a/copasi/bindings/swig/CCopasiTask.i
+++ b/copasi/bindings/swig/CCopasiTask.i
@@ -144,7 +144,17 @@
         assert(pDataModel!=NULL);
 
         // Initialize the task
-        success = self->initialize((CCopasiTask::OutputFlag)outputFlags, pDataModel, NULL);
+        try
+        {
+          success = self->initialize((CCopasiTask::OutputFlag)outputFlags, pDataModel, NULL);
+        }
+        
+        catch (CCopasiException &)
+        {
+          success = false;
+        }
+        
+        catch (...) {}
 
         return success;
     }
@@ -184,7 +194,17 @@
         assert(pDataModel!=NULL);
 
         // Process the task
-        success = self->process(useInitialValues);
+        try
+        {
+          success = self->process(useInitialValues);
+        }
+        
+        catch (CCopasiException &)
+        {
+          success = false;
+        }
+        
+        catch (...) {}
 
         self->restore();
 


### PR DESCRIPTION
I inadvertently removed the catch for CCopasiExceptions for my processRaw and initializeRaw task methods.
I need those checks back to prevent crashes.

Sorry about the inconvenience.