### PR TITLE
Fix name of log verbosity parameter

### DIFF
--- a/copasi/optimization/COptMethodCoranaWalk.cpp
+++ b/copasi/optimization/COptMethodCoranaWalk.cpp
@@ -39,7 +39,7 @@ COptMethodCoranaWalk::COptMethodCoranaWalk(const CDataContainer * pParent,
   addParameter("Random Number Generator", CCopasiParameter::UINT, (unsigned C_INT32) CRandom::mt19937);
   addParameter("Seed", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -290,7 +290,7 @@ bool COptMethodCoranaWalk::initialize()
 
   if (!COptMethod::initialize()) return false;
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mTemperature = getValue< C_FLOAT64 >("Temperature");
   mIterations = getValue< unsigned C_INT32 >("Iterations");

--- a/copasi/optimization/COptMethodDE.cpp
+++ b/copasi/optimization/COptMethodDE.cpp
@@ -47,7 +47,7 @@ COptMethodDE::COptMethodDE(const CDataContainer * pParent,
     addParameter("Stop after # Stalled Generations", CCopasiParameter::UINT, (unsigned C_INT32) 0);
   }
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -338,7 +338,7 @@ bool COptMethodDE::initialize()
     return false;
   }
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mGenerations = getValue< unsigned C_INT32 >("Number of Generations");
   mCurrentGeneration = 0;

--- a/copasi/optimization/COptMethodEP.cpp
+++ b/copasi/optimization/COptMethodEP.cpp
@@ -50,7 +50,7 @@ COptMethodEP::COptMethodEP(const CDataContainer * pParent,
   addParameter("Stop after # Stalled Generations", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -184,7 +184,7 @@ bool COptMethodEP::initialize()
   if (!COptPopulationMethod::initialize()) return false;
 
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mGenerations = getValue< unsigned C_INT32 >("Number of Generations");
   mCurrentGeneration = 0;

--- a/copasi/optimization/COptMethodGA.cpp
+++ b/copasi/optimization/COptMethodGA.cpp
@@ -65,7 +65,7 @@ COptMethodGA::COptMethodGA(const CDataContainer * pParent,
     addParameter("Stop after # Stalled Generations", CCopasiParameter::UINT, (unsigned C_INT32) 0);
   }
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -431,7 +431,7 @@ bool COptMethodGA::initialize()
 
   mIndividuals.resize(2 * mPopulationSize);
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mGenerations = (unsigned C_INT32)getValue< unsigned C_INT32 >("Number of Generations");
   mCurrentGeneration = 0;

--- a/copasi/optimization/COptMethodGASR.cpp
+++ b/copasi/optimization/COptMethodGASR.cpp
@@ -57,7 +57,7 @@ COptMethodGASR::COptMethodGASR(const CDataContainer * pParent,
     addParameter("Stop after # Stalled Generations", CCopasiParameter::UINT, (unsigned C_INT32) 0);
   }
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -405,7 +405,7 @@ bool COptMethodGASR::initialize()
 
   if (!COptPopulationMethod::initialize()) return false;
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mCurrentGeneration = 0;
   mGenerations = getValue< unsigned C_INT32 >("Number of Generations");

--- a/copasi/optimization/COptMethodHookeJeeves.cpp
+++ b/copasi/optimization/COptMethodHookeJeeves.cpp
@@ -44,7 +44,7 @@ COptMethodHookeJeeves::COptMethodHookeJeeves(const CDataContainer * pParent,
   addParameter("Tolerance", CCopasiParameter::DOUBLE, (C_FLOAT64) 1.e-005);
   addParameter("Rho", CCopasiParameter::DOUBLE, (C_FLOAT64) 0.2);
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -251,7 +251,7 @@ bool COptMethodHookeJeeves::initialize()
 
   if (!COptMethod::initialize()) return false;
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mIterationLimit = getValue< unsigned C_INT32 >("Iteration Limit");
   mTolerance = getValue< C_FLOAT64 >("Tolerance");

--- a/copasi/optimization/COptMethodLevenbergMarquardt.cpp
+++ b/copasi/optimization/COptMethodLevenbergMarquardt.cpp
@@ -70,7 +70,7 @@ COptMethodLevenbergMarquardt::COptMethodLevenbergMarquardt(const CDataContainer 
     addParameter("Stop after # Stalled Iterations", CCopasiParameter::UINT, (unsigned C_INT32) 0);
   }
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -461,7 +461,7 @@ bool COptMethodLevenbergMarquardt::initialize()
   mModulation = 0.001;
   mIterationLimit = getValue< unsigned C_INT32 >("Iteration Limit");
   mTolerance = getValue< C_FLOAT64 >("Tolerance");
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   if (getParameter("Modulation"))
   mModulation = getValue< C_FLOAT64 >("Modulation");

--- a/copasi/optimization/COptMethodNelderMead.cpp
+++ b/copasi/optimization/COptMethodNelderMead.cpp
@@ -41,7 +41,7 @@ COptMethodNelderMead::COptMethodNelderMead(const CDataContainer * pParent,
   addParameter("Tolerance", CCopasiParameter::UDOUBLE, (C_FLOAT64) 1.e-005);
   addParameter("Scale", CCopasiParameter::UDOUBLE, (C_FLOAT64) 10.0);
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -661,7 +661,7 @@ bool COptMethodNelderMead::initialize()
   mIterationLimit = getValue< unsigned C_INT32 >("Iteration Limit");
   mTolerance = getValue< C_FLOAT64 >("Tolerance");
   mScale = getValue< C_FLOAT64 >("Scale");
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mIteration = 0;
 

--- a/copasi/optimization/COptMethodPS.cpp
+++ b/copasi/optimization/COptMethodPS.cpp
@@ -58,7 +58,7 @@ COptMethodPS::COptMethodPS(const CDataContainer * pParent,
   if (mEnableAdditionalParameters)
   addParameter("Stop after # Stalled Iterations", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -329,7 +329,7 @@ bool COptMethodPS::initialize()
 
   mGenerations = getValue< unsigned C_INT32 >("Iteration Limit");
   mCurrentGeneration = 0;
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   if (mpCallBack)
     mhGenerations =

--- a/copasi/optimization/COptMethodPraxis.cpp
+++ b/copasi/optimization/COptMethodPraxis.cpp
@@ -36,7 +36,7 @@ COptMethodPraxis::COptMethodPraxis(const CDataContainer * pParent,
 {
   addParameter("Tolerance", CCopasiParameter::DOUBLE, (C_FLOAT64) 1.e-005);
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -143,7 +143,7 @@ bool COptMethodPraxis::initialize()
 
   if (!COptMethod::initialize()) return false;
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mTolerance = getValue< C_FLOAT64 >("Tolerance");
   mIteration = 0;

--- a/copasi/optimization/COptMethodSA.cpp
+++ b/copasi/optimization/COptMethodSA.cpp
@@ -48,7 +48,7 @@ COptMethodSA::COptMethodSA(const CDataContainer * pParent,
   addParameter("Random Number Generator", CCopasiParameter::UINT, (unsigned C_INT32) CRandom::mt19937);
   addParameter("Seed", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -330,7 +330,7 @@ bool COptMethodSA::initialize()
   mTemperature = getValue< C_FLOAT64 >("Start Temperature");
   mCoolingFactor = getValue< C_FLOAT64 >("Cooling Factor");
   mTolerance = getValue< C_FLOAT64 >("Tolerance");
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
   mpRandom =
     CRandom::createGenerator((CRandom::Type) getValue< unsigned C_INT32 >("Random Number Generator"),
                              getValue< unsigned C_INT32 >("Seed"));

--- a/copasi/optimization/COptMethodSRES.cpp
+++ b/copasi/optimization/COptMethodSRES.cpp
@@ -55,7 +55,7 @@ COptMethodSRES::COptMethodSRES(const CDataContainer * pParent,
   if (mEnableAdditionalParameters)
   addParameter("Stop after # Stalled Generations", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -510,7 +510,7 @@ bool COptMethodSRES::initialize()
 
   if (!COptPopulationMethod::initialize()) return false;
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mGenerations = getValue< unsigned C_INT32 >("Number of Generations");
   mCurrentGeneration = 0;

--- a/copasi/optimization/COptMethodSteepestDescent.cpp
+++ b/copasi/optimization/COptMethodSteepestDescent.cpp
@@ -46,7 +46,7 @@ COptMethodSteepestDescent::COptMethodSteepestDescent(const CDataContainer * pPar
   addParameter("Iteration Limit", CCopasiParameter::UINT, (unsigned C_INT32) 100);
   addParameter("Tolerance", CCopasiParameter::DOUBLE, (C_FLOAT64) 1e-6);
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
 }
 
@@ -227,7 +227,7 @@ bool COptMethodSteepestDescent::initialize()
 
   if (!COptMethod::initialize()) return false;
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mIterations = getValue< unsigned C_INT32 >("Iteration Limit");
   mTolerance = getValue< C_FLOAT64 >("Tolerance");

--- a/copasi/optimization/COptMethodTruncatedNewton.cpp
+++ b/copasi/optimization/COptMethodTruncatedNewton.cpp
@@ -35,7 +35,7 @@ COptMethodTruncatedNewton::COptMethodTruncatedNewton(const CDataContainer * pPar
   mpCTruncatedNewton(new CTruncatedNewton())
 {
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -257,7 +257,7 @@ bool COptMethodTruncatedNewton::initialize()
 
   if (!COptMethod::initialize()) return false;
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mVariableSize = (C_INT) mpOptItem->size();
   mCurrent.resize(mVariableSize);

--- a/copasi/optimization/CRandomSearch.cpp
+++ b/copasi/optimization/CRandomSearch.cpp
@@ -52,7 +52,7 @@ CRandomSearch::CRandomSearch(const CDataContainer * pParent,
   addParameter("Random Number Generator", CCopasiParameter::UINT, (unsigned C_INT32) CRandom::mt19937);
   addParameter("Seed", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
-  addParameter("#LogVerbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
+  addParameter("Log Verbosity", CCopasiParameter::UINT, (unsigned C_INT32) 0);
 
   initObjects();
 }
@@ -87,7 +87,7 @@ bool CRandomSearch::initialize()
 
   if (!COptMethod::initialize()) return false;
 
-  mLogVerbosity = getValue< unsigned C_INT32 >("#LogVerbosity");
+  mLogVerbosity = getValue< unsigned C_INT32 >("Log Verbosity");
 
   mIterations = getValue< unsigned C_INT32 >("Number of Iterations");
   mpRandom = & mpContainer->getRandomGenerator();


### PR DESCRIPTION
Back when I implemented the log functionality I had a workaround for the method parameter for log verbosity, which is why I called it "#LogVerbosity".
I had to remove the workaround and now the parameter should really have a decent name.
I changed all occurences of "#LogVerbosity" to "Log Verbosity".