### PR TITLE
Support CMake 4.0 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@
 ###############################################################################
 
 # we need at least cmake 2.8 for the FindLAPACK functions
-cmake_minimum_required (VERSION 2.8.12...3.19.1)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/ChooseQtVersion.cmake
+++ b/ChooseQtVersion.cmake
@@ -8,7 +8,7 @@
 # of Connecticut School of Medicine. 
 # All rights reserved. 
 
-cmake_minimum_required (VERSION 2.8.12...3.19.1)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 set(SELECT_QT "Any" CACHE STRING "The prefered Qt version one of: Qt6, Qt5, Qt4 or Any" )
 if (DEFINED SELECT_QT)

--- a/copasi/CMakeLists.txt
+++ b/copasi/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12...3.19.1)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/CopasiSBW/CMakeLists.txt
+++ b/copasi/CopasiSBW/CMakeLists.txt
@@ -13,7 +13,7 @@
 # of Manchester. 
 # All rights reserved. 
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if (SBW_FOUND)
 

--- a/copasi/CopasiUI/CMakeLists.txt
+++ b/copasi/CopasiUI/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12...3.19.1)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/ViewCurrentUI/CMakeLists.txt
+++ b/copasi/ViewCurrentUI/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 project (ViewCurrentUI)
 
 if (NOT BUILD_GUI)

--- a/copasi/bindings/CMakeLists.txt
+++ b/copasi/bindings/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/assignParameterSet/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/assignParameterSet/CMakeLists.txt
@@ -22,7 +22,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/calculateSolutionStatistic/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/calculateSolutionStatistic/CMakeLists.txt
@@ -22,7 +22,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/changeValues/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/changeValues/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example1/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example1/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example10/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example10/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example2/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example2/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example3/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example3/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example4/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example4/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example5/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example5/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example6/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example6/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example7/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example7/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example8/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example8/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/example9/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/example9/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/exportSedML/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/exportSedML/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/printAffectedExperiments/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/printAffectedExperiments/CMakeLists.txt
@@ -22,7 +22,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/printFluxModes/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/printFluxModes/CMakeLists.txt
@@ -22,7 +22,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/renameActiveReport/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/renameActiveReport/CMakeLists.txt
@@ -22,7 +22,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/renderLayout/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/renderLayout/CMakeLists.txt
@@ -25,7 +25,7 @@
 # only create this example if we build the gui
 if (BUILD_GUI)
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0020)
   cmake_policy(SET CMP0020 NEW)

--- a/copasi/bindings/cpp_examples/runScan/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/runScan/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/bindings/cpp_examples/runSedML/CMakeLists.txt
+++ b/copasi/bindings/cpp_examples/runSedML/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/copasi/compareExpressions/stresstest/CMakeLists.txt
+++ b/copasi/compareExpressions/stresstest/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 project (compareExpressions-stresstest)
 
 include_directories(

--- a/copasi/compareExpressions/unittests/CMakeLists.txt
+++ b/copasi/compareExpressions/unittests/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 project (compareExpressions-unittests)
 
 include_directories(

--- a/copasi/sbml/unittests/CMakeLists.txt
+++ b/copasi/sbml/unittests/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 project (sbml-unittests)
 
 include_directories(

--- a/copasi/sedml/CMakeLists.txt
+++ b/copasi/sedml/CMakeLists.txt
@@ -26,7 +26,7 @@
 #
 ###############################################################################
 
-#cmake_minimum_required (VERSION 2.8.12)
+#cmake_minimum_required(VERSION 2.8...3.19)
 
 
 file(GLOB HEADERS_SEDML sedml/*.h)

--- a/franks_testsuite/CMakeLists.txt
+++ b/franks_testsuite/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/mca_test_wrapper/CMakeLists.txt
+++ b/mca_test_wrapper/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required(VERSION 2.8...3.19)
 project (mca_test_wrapper)
 
 

--- a/sbml-testsuite/CMakeLists.txt
+++ b/sbml-testsuite/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)

--- a/semantic-test-suite/CMakeLists.txt
+++ b/semantic-test-suite/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required(VERSION 2.8...3.19)
 project (semantic-test-suite)
 
 set(SOURCES ${SOURCES} copasi_wrapper.cpp)

--- a/steady_state_test_wrapper/CMakeLists.txt
+++ b/steady_state_test_wrapper/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required(VERSION 2.8...3.19)
 project (steady_state_test_wrapper)
 
 set(SOURCES ${SOURCES} copasi_wrapper.cpp)

--- a/stochastic-testsuite/CMakeLists.txt
+++ b/stochastic-testsuite/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8...3.19)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)


### PR DESCRIPTION
Things like `if(POLICY CMP0048)` can also be avoided here, but I want to first unblock the Fedora builds for CMake 4.0