### PR TITLE
Do not expand function calls when creating DiscontinuityDataEvents to fix bug (crash)

### DIFF
--- a/copasi/math/CMathContainer.cpp
+++ b/copasi/math/CMathContainer.cpp
@@ -4701,51 +4701,45 @@ void CMathContainer::createDiscontinuityEvents()
 
   for (; it != end; ++it)
     {
-      createDiscontinuityEvents(*it, Variables);
+      const CEvaluationNode *startNode = (*it)->getRoot();
+      createDiscontinuityEvents(startNode);
     }
 }
 
-void CMathContainer::createDiscontinuityEvents(const CEvaluationTree * pTree,
-    const std::vector< CEvaluationNode * > & variables)
+void CMathContainer::createDiscontinuityEvents(const CEvaluationNode * Node)
 {
-  // We create an AST in which all function calls are expanded
-  CEvaluationNode * pRoot = copyBranch(pTree->getRoot(), variables, false);
+  // We don't need to expand function calls here
 
-  CNodeIterator< CEvaluationNode  > itNode(pRoot);
+  if (Node == NULL) {
+    return;
+  }
+  createDiscontinuityEvents(static_cast<const CEvaluationNode *>(Node->getChild()));
 
-  while (itNode.next() != itNode.end())
-    {
-      if (*itNode == NULL)
-        {
-          continue;
-        }
+  switch (Node->mainType() | Node->subType())
+  {
+    case (CEvaluationNode::MainType::CHOICE | CEvaluationNode::SubType::IF):
+    case (CEvaluationNode::MainType::FUNCTION | CEvaluationNode::SubType::FLOOR):
+    case (CEvaluationNode::MainType::FUNCTION | CEvaluationNode::SubType::CEIL):
+    case (CEvaluationNode::MainType::OPERATOR | CEvaluationNode::SubType::MODULUS):
+    case (CEvaluationNode::MainType::OPERATOR | CEvaluationNode::SubType::REMAINDER):
+    case (CEvaluationNode::MainType::OPERATOR | CEvaluationNode::SubType::QUOTIENT):
+    case (CEvaluationNode::MainType::OPERATOR | CEvaluationNode::SubType::IMPLIES):
+      createDiscontinuityDataEvent(Node);
+      break;
 
-      switch (itNode->mainType() | itNode->subType())
-        {
-          case (CEvaluationNode::MainType::CHOICE | CEvaluationNode::SubType::IF):
-          case (CEvaluationNode::MainType::FUNCTION | CEvaluationNode::SubType::FLOOR):
-          case (CEvaluationNode::MainType::FUNCTION | CEvaluationNode::SubType::CEIL):
-          case (CEvaluationNode::MainType::OPERATOR | CEvaluationNode::SubType::MODULUS):
-          case (CEvaluationNode::MainType::OPERATOR | CEvaluationNode::SubType::REMAINDER):
-          case (CEvaluationNode::MainType::OPERATOR | CEvaluationNode::SubType::QUOTIENT):
-          case (CEvaluationNode::MainType::OPERATOR | CEvaluationNode::SubType::IMPLIES):
-            createDiscontinuityDataEvent(*itNode);
-            break;
+    // Call nodes and variables are eliminated.
+    case (CEvaluationNode::MainType::CALL | CEvaluationNode::SubType::FUNCTION):
+    case (CEvaluationNode::MainType::CALL | CEvaluationNode::SubType::EXPRESSION):
+      {
+        const CEvaluationTree * pCalledTree = static_cast< const CEvaluationNodeCall * >(Node)->getCalledTree();
+        createDiscontinuityEvents(pCalledTree->getRoot());
+        break;
+      }
 
-          // Call nodes and variables are eliminated.
-          case (CEvaluationNode::MainType::CALL | CEvaluationNode::SubType::FUNCTION):
-          case (CEvaluationNode::MainType::CALL | CEvaluationNode::SubType::EXPRESSION):
-          case (CEvaluationNode::MainType::VARIABLE | CEvaluationNode::SubType::DEFAULT):
-            fatalError();
-            break;
-
-          default:
-            break;
-        }
-    }
-
-  pdelete(pRoot);
-
+    default:
+      break;
+  }
+  createDiscontinuityEvents(static_cast<const CEvaluationNode *>(Node->getSibling()));
   return;
 }
 

--- a/copasi/math/CMathContainer.cpp
+++ b/copasi/math/CMathContainer.cpp
@@ -4697,7 +4697,6 @@ void CMathContainer::createDiscontinuityEvents()
   std::vector< const CEvaluationTree * >::const_iterator it = TreesWithDiscontinuities.begin();
   std::vector< const CEvaluationTree * >::const_iterator end = TreesWithDiscontinuities.end();
 
-  std::vector< CEvaluationNode * > Variables;
 
   for (; it != end; ++it)
     {

--- a/copasi/math/CMathContainer.h
+++ b/copasi/math/CMathContainer.h
@@ -1113,8 +1113,7 @@ private:
    * @param const CEvaluationTree * pTree
    * @param const std::vector< CEvaluationNode * > & variables
    */
-  void createDiscontinuityEvents(const CEvaluationTree * pTree,
-                                 const std::vector< CEvaluationNode * > & variables);
+  void createDiscontinuityEvents(const CEvaluationNode * pNode);
 
   /**
    * Create an event of type CEvent::Discontinuity for the given node


### PR DESCRIPTION
When I open SBML file [example_crash.xml](https://github.com/user-attachments/files/24338620/example_crash.xml) (generated by [example_crash.py](https://github.com/user-attachments/files/24338621/example_crash.py)) with COPASI and try to run time course, COPASI crashes (and it also crashes on similar files). To fix this, I propose this pull request.

In fact, example_crash.xml contains two functions (`myfun: x -> x + x` (important part here is that x appears more than once) and `relu: x -> piecewise(x, x>0, 0)` (important that this function creates discontinuity)) and an assignment rule `output = myfun(relu(time-0.5))`. In the original code, in [createDiscontinuityEvents](https://github.com/copasi/COPASI/blob/develop/copasi/math/CMathContainer.cpp#L4708) function calls are unrolled because `CopyBranch` with `replaceDiscontinuousNodes=false` does so, so we get something like `output = piecewise((time-0.5), (time-0.5)>0, 0) + piecewise((time-0.5), (time-0.5)>0, 0)` and create two discontinuities. But when we fill discontinuities in [compileObjects](https://github.com/copasi/COPASI/blob/develop/copasi/math/CMathContainer.cpp#L1523) it stores arguments of functions, including the case when they are also functions, and in this case it proceeds `relu` only once, and fills `mpCalculate` of corresponding discontinuity only once. Because of this, at the end we have the second discontinuity with `mpCalculate` equal to `NULL`, and when, during time course, we try to call it (in [calculateValue](https://github.com/copasi/COPASI/blob/develop/copasi/math/CMathObject.cpp#L353)), program crashes.

I'm not sure that my code is good and COPASI'sh, I'm very open to any suggestions.

Also, my version works with my SBMLs, but I don't understand how to run COPASI tests, maybe you can help with this?