### PR TITLE
Fix RAPTOR::RAPTOR linking: propagate libxml2 (shared) dependency

### DIFF
--- a/CMakeModules/FindRAPTOR.cmake
+++ b/CMakeModules/FindRAPTOR.cmake
@@ -129,11 +129,20 @@ if (NOT RAPTOR_FOUND AND Raptor_FIND_VERSION_MAJOR EQUAL "2" AND NOT Raptor_FIND
     endif ()
 endif ()
 
+# Raptor (built with libxml2 SAX2 support) requires libxml2 at link time.
+# Prefer shared libxml2 over static to avoid missing transitive deps (zlib, lzma, icu)
+find_library(LIBXML2_LIBRARY NAMES libxml2.so xml2)
+find_package(LibXml2 QUIET)
+
 if(NOT TARGET RAPTOR::RAPTOR)
   add_library(RAPTOR::RAPTOR UNKNOWN IMPORTED)
   set_target_properties(RAPTOR::RAPTOR PROPERTIES
     IMPORTED_LOCATION "${RAPTOR_LIBRARY}"
     INTERFACE_INCLUDE_DIRECTORIES "${RAPTOR_INCLUDE_DIR}")
+  if (LibXml2_FOUND)
+    set_property(TARGET RAPTOR::RAPTOR APPEND PROPERTY
+      INTERFACE_LINK_LIBRARIES LibXml2::LibXml2)
+  endif ()
 endif()
 
 if ((WIN32 AND NOT CYGWIN) AND RAPTOR_FOUND)


### PR DESCRIPTION
## Problem

When building COPASI with `COPASI_USE_RAPTOR=ON` against a Raptor build that includes libxml2 SAX2 support, linking `CopasiSE` (and any other target linking `RAPTOR::RAPTOR`) fails with undefined references to `xmlSAX2*`, `xmlParseChunk`, `xmlFree`, etc.

This happens because `FindRAPTOR.cmake` creates the `RAPTOR::RAPTOR` imported target without declaring libxml2 as an interface link dependency, even though the underlying `libraptor.a` was built with libxml2 support.

Additionally, on systems where `find_package(LibXml2)` resolves to the static `libxml2.a` (e.g. recent Debian/Ubuntu with both static and shared libxml2 installed), linking fails a second time with undefined references to zlib (`gzopen`, `gzread`...), liblzma (`lzma_code`...), and ICU (`ucnv_open_74`...) symbols, since those transitive static dependencies aren't propagated automatically.

## Fix

In `CMakeModules/FindRAPTOR.cmake`:
- Explicitly search for and prefer the **shared** libxml2 library via `find_library(LIBXML2_LIBRARY NAMES libxml2.so xml2)` before calling `find_package(LibXml2 QUIET)`, avoiding the static-linking transitive dependency problem entirely.
- Append `LibXml2::LibXml2` to `RAPTOR::RAPTOR`'s `INTERFACE_LINK_LIBRARIES` so all consumers of the target (`libCOPASISE-core`, `libCOPASISE-static`, `libCOPASISE-shared`) automatically get the correct link flags.

## Testing

Verified on Ubuntu/Linux Mint (GCC 13.3.0) with a fresh `copasi-dependencies` build (Raptor built from source with libxml2 support) — `CopasiSE` now configures and links cleanly with no manual linker flags required, whereas previously `CMAKE_EXE_LINKER_FLAGS"=-lxml2"` had to be passed manually as a workaround.